### PR TITLE
Update radio-settings.mdx

### DIFF
--- a/docs/about/overview/radio-settings.mdx
+++ b/docs/about/overview/radio-settings.mdx
@@ -80,7 +80,7 @@ Various data-rate options are available when configuring a frequency slot and ar
 
 We have eight LoRa radio presets. These are the most common settings and have been proven to work well:
 
-|    Channel setting     | Alt Channel Name | Data-Rate  | SF / Symbols | Coding Rate |  Bandwidth   | Link Budget |
+|    Preset              | Alt Preset Name  | Data-Rate  | SF / Symbols | Coding Rate |  Bandwidth   | Link Budget |
 | :--------------------: | :--------------: | :--------: | :----------: | :---------: | :----------: | :---------: |
 |  Short Range / Turbo   |   Short Turbo    | 21.88 kbps |   7 / 128    |     4/5     |  500 kHz[^1] |    140dB    |
 |   Short Range / Fast   |    Short Fast    | 10.94 kbps |   7 / 128    |     4/5     |    250 kHz   |    143dB    |


### PR DESCRIPTION
Changed preset table column header away from using the word Channel as that has another meaning in Meshtastic that is not the same as what is in the table.

## What did you change
The column titles of the first two columns in the table of radio presets. Changed from "Channel setting" to "Preset", and from "Alt channel name" to "Alt preset name". 

## Why did you change it
The use of the term Channel in this table is confusing because Meshtastic defines Channels as communication mesh overlays, not presets. Using the term here, while it may be technically correct, encourages confusion when the user later reads about Channels and configuring them. 

## Screenshots
### Before
![Screenshot 2025-04-14 at 12 15 26 PM](https://github.com/user-attachments/assets/dc3fed5c-5a1f-4a21-88c1-22de084e777c)

### After
![Screenshot 2025-04-14 at 12 15 55 PM](https://github.com/user-attachments/assets/545ee4e6-f247-4cb6-a003-df6b5135478a)

